### PR TITLE
Improve pathfinding

### DIFF
--- a/1.4/Defs/MerfolkAquaticDefs.xml
+++ b/1.4/Defs/MerfolkAquaticDefs.xml
@@ -28,6 +28,20 @@
         <exclusionTags>
             <li>FireDamage</li>
         </exclusionTags>
+        <modExtensions>
+            <!-- Gives pawns with this gene the PF_Movement_Merren movement type. -->
+            <li Class="PathfindingFramework.MovementExtension">
+                <movementDef>PF_Movement_Merren</movementDef>
+            </li>
+        </modExtensions>
+        <conditionalStatAffecters>
+            <!-- Applies a -3 move speed debuff to pawns with this gene not in water. -->
+            <li Class="StagzMerfolk.ConditionalStatEffector_NotWater">
+                <statOffsets>
+                    <MoveSpeed>-3</MoveSpeed>
+                </statOffsets>
+            </li>
+        </conditionalStatAffecters>
     </GeneDef>
     <NeedDef>
         <defName>Stagz_NeedAquatic</defName>

--- a/1.4/Defs/PF_MovementTypeDefs.xml
+++ b/1.4/Defs/PF_MovementTypeDefs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+    <PathfindingFramework.MovementDef>
+        <defName>PF_Movement_Merren</defName>
+        <label>merren</label>
+        <description>Merren movement prefers water, but will move on land if needed.</description>
+        <priority>2000</priority>
+        <tagCosts>
+            <PF_TerrainTag_WaterDeep>0</PF_TerrainTag_WaterDeep>
+            <PF_TerrainTag_WaterChestDeep>2</PF_TerrainTag_WaterChestDeep>
+            <PF_TerrainTag_WaterShallow>4</PF_TerrainTag_WaterShallow>
+        </tagCosts>
+        <defaultCost>Unsafe</defaultCost>
+        <ignoreAvoidWander>true</ignoreAvoidWander>
+    </PathfindingFramework.MovementDef>
+</Defs>

--- a/About/About.xml
+++ b/About/About.xml
@@ -17,6 +17,11 @@ This mod adds new genes that interact with water, new abilities themed around wa
       <downloadUrl>https://github.com/pardeike/HarmonyRimWorld/releases/latest</downloadUrl>
     </li>
     <li>
+      <packageId>pathfinding.framework</packageId>
+      <displayName>Pathfinding Framework</displayName>
+      <steamWorkshopUrl>steam://url/CommunityFilePage/3070914628</steamWorkshopUrl>
+    </li>
+    <li>
       <packageId>Ludeon.RimWorld.Biotech</packageId>
       <displayName>Biotech</displayName>
     </li>
@@ -29,6 +34,7 @@ This mod adds new genes that interact with water, new abilities themed around wa
     <li>VanillaExpanded.VPlantsE</li>
     <li>VanillaExpanded.VPlantsEMore</li>
     <li>dubwise.dubsbadhygiene</li>
+    <li>pathfinding.framework</li>
   </loadAfter>
 </ModMetaData>
 


### PR DESCRIPTION
This PR adds [https://github.com/joseasoler/Pathfinding-Framework](Pathfinding Framework) as a mod dependency to improve movement for Merren xenos while keeping code light. All pawns with the aquatic gene receive a -3 move speed debuff on land, and will also prefer to pathfind in water sources only. So even if the pawn is on land they will try to reach for water.

Only issue so far is Merrens can't be ordered to move back on land, but at least this fix brings it closer towards the expectation. Maybe there could be an ability (landwalk?) that temporarily grants Merrens ability to move on land and water for a short time before returning to default water-only.