### PR TITLE
Replace Always-On GenHostility patch with Dynamic Version

### DIFF
--- a/Source/StagzMerfolk/HarmonyPatches/GenHostility_Patches.cs
+++ b/Source/StagzMerfolk/HarmonyPatches/GenHostility_Patches.cs
@@ -1,14 +1,85 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
 using HarmonyLib;
 using RimWorld;
 using Verse;
 
 namespace StagzMerfolk.HarmonyPatches;
 
-[HarmonyPatch(typeof(GenHostility), "HostileTo", new[] { typeof(Thing), typeof(Thing) })]
-public static class GenHostility_HostileTo_Patch
+internal static class CharmedHostilityPatcher
 {
-    private static void Postfix(Thing a, Thing b, ref bool __result)
+    private const string HarmonyId = "com.arquebus.rimworld.mod.stagzmerfolk.charmedhostility";
+
+    private static readonly Harmony Harmony = new Harmony(HarmonyId);
+    private static readonly HashSet<Pawn> ActiveCharmedPawns = new HashSet<Pawn>();
+    private static readonly MethodInfo HostileToThingMethod = AccessTools.Method(typeof(GenHostility), nameof(GenHostility.HostileTo), new[] { typeof(Thing), typeof(Thing) });
+    private static readonly MethodInfo HostileToFactionMethod = AccessTools.Method(typeof(GenHostility), nameof(GenHostility.HostileTo), new[] { typeof(Thing), typeof(Faction) });
+    private static readonly HarmonyMethod HostileToThingPostfix = new HarmonyMethod(typeof(CharmedHostilityPatcher), nameof(PostfixHostileToThing));
+    private static readonly HarmonyMethod HostileToFactionPostfix = new HarmonyMethod(typeof(CharmedHostilityPatcher), nameof(PostfixHostileToFaction));
+
+    private static bool patched;
+
+    public static void Register(Pawn pawn)
+    {
+        if (pawn == null)
+        {
+            return;
+        }
+
+        ActiveCharmedPawns.Add(pawn);
+        EnsurePatched();
+    }
+
+    public static void Unregister(Pawn pawn)
+    {
+        if (pawn != null)
+        {
+            ActiveCharmedPawns.Remove(pawn);
+        }
+
+        PruneInactivePawns();
+        if (ActiveCharmedPawns.Count == 0)
+        {
+            Unpatch();
+        }
+    }
+
+    private static void EnsurePatched()
+    {
+        if (patched)
+        {
+            return;
+        }
+
+        Harmony.Patch(HostileToThingMethod, postfix: HostileToThingPostfix);
+        Harmony.Patch(HostileToFactionMethod, postfix: HostileToFactionPostfix);
+        patched = true;
+    }
+
+    private static void Unpatch()
+    {
+        if (!patched)
+        {
+            return;
+        }
+
+        Harmony.Unpatch(HostileToThingMethod, HarmonyPatchType.Postfix, HarmonyId);
+        Harmony.Unpatch(HostileToFactionMethod, HarmonyPatchType.Postfix, HarmonyId);
+        patched = false;
+    }
+
+    private static void PruneInactivePawns()
+    {
+        ActiveCharmedPawns.RemoveWhere(pawn => pawn == null || !IsCharmed(pawn));
+    }
+
+    private static bool IsCharmed(Pawn pawn)
+    {
+        var def = pawn?.MentalState?.def;
+        return def == StagzDefOf.Stagz_Charmed || def == StagzDefOf.Stagz_VeryCharmed;
+    }
+
+    private static void PostfixHostileToThing(Thing a, Thing b, ref bool __result)
     {
         if (a.Destroyed || b.Destroyed || a == b)
         {
@@ -16,25 +87,20 @@ public static class GenHostility_HostileTo_Patch
         }
 
         if (a is Pawn { Faction: not null } aPawn && b is Pawn { Faction: not null } bPawn &&
-            (aPawn.MentalState != null && StagzCollections.StateDefs.Contains(aPawn.MentalState.def) || bPawn.MentalState != null && StagzCollections.StateDefs.Contains(bPawn.MentalState.def))
-           )
+            (IsCharmed(aPawn) || IsCharmed(bPawn)))
         {
             __result = aPawn.Faction == bPawn.Faction;
         }
     }
-}
 
-[HarmonyPatch(typeof(GenHostility), "HostileTo", new[] { typeof(Thing), typeof(Faction) })]
-public static class GenHostility_HostileToFaction_Patch
-{
-    private static void Postfix(Thing t, Faction fac, ref bool __result)
+    private static void PostfixHostileToFaction(Thing t, Faction fac, ref bool __result)
     {
         if (t.Destroyed || fac == null)
         {
             return;
         }
 
-        if (t is Pawn { Faction: not null, MentalState: not null } pawn && StagzCollections.StateDefs.Contains(pawn.MentalState.def))
+        if (t is Pawn { Faction: not null } pawn && IsCharmed(pawn))
         {
             __result = pawn.Faction == fac;
         }

--- a/Source/StagzMerfolk/MentalStates/MentalState_Charmed.cs
+++ b/Source/StagzMerfolk/MentalStates/MentalState_Charmed.cs
@@ -1,4 +1,5 @@
-﻿using RimWorld;
+using RimWorld;
+using StagzMerfolk.HarmonyPatches;
 using Verse;
 using Verse.AI;
 
@@ -8,15 +9,20 @@ public class MentalState_Charmed : MentalState
 {
     public float charmChance;
 
+    public MentalState_Charmed()
+    {
+        this.charmChance = 0.01f;
+    }
+
     public override void ExposeData()
     {
         base.ExposeData();
         Scribe_Values.Look<float>(ref this.charmChance, "charmChance", 0.1f, false);
-    }
 
-    public MentalState_Charmed()
-    {
-        this.charmChance = 0.01f;
+        if (Scribe.mode == LoadSaveMode.PostLoadInit)
+        {
+            CharmedHostilityPatcher.Register(pawn);
+        }
     }
 
     public override RandomSocialMode SocialModeMax()
@@ -24,9 +30,16 @@ public class MentalState_Charmed : MentalState
         return RandomSocialMode.Off;
     }
 
+    public override void PostStart(string reason)
+    {
+        base.PostStart(reason);
+        CharmedHostilityPatcher.Register(pawn);
+    }
+
     public override void PostEnd()
     {
         base.PostEnd();
+        CharmedHostilityPatcher.Unregister(pawn);
 
         pawn.mindState.mentalStateHandler.TryStartMentalState(MentalStateDefOf.PanicFlee);
         if (pawn.RaceProps.Humanlike && Rand.Chance(charmChance))


### PR DESCRIPTION
Replaces the always-on GenHostility harmony patch with one that patches and unpatches based on whether or not there are any currently charmed pawns. 

Made this patch after noticing GenHostility popping up pretty high in Performance Analyzer. 

Results in around a 10% performance increase of GenHostility method calls when there are no charmed pawns, in a mid-game-ish sized colony with 20-30 pawns. More impact the more pawns/animals/turrets etc. are active.

Pretty small in the grand scheme of things tbh, but figured I would PR anyway in case you'd like to implement it.

PS I've been a professional .NET developer for around a decade, but have only dipped my toes into RimWorld/Harmony modding, so if anything I've done looks silly, let me know, I appreciate any pointers!

PR does not include a recompiled dll, but I can if it's preferred over rebuilding yourself.